### PR TITLE
Integrate popup to inline view

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -179,7 +179,7 @@ export default function RootLayout({
   }
 
   return (
-    <html lang="en" suppressHydrationWarning className="overflow-hidden">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <link rel="icon" href="/favicon.ico" sizes="any" />
         <link rel="icon" href="/logo.png" type="image/png" />

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -3,7 +3,7 @@ import { VERSION } from '@/lib/version'
 
 export function Footer() {
   return (
-    <footer className="sticky bottom-0 z-50 w-full border-t bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+    <footer className="sticky bottom-0 z-[60] w-full border-t bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="container m-auto px-8 flex h-14 items-center justify-between">
         <div className="flex items-center gap-4">
           <a

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -11,7 +11,7 @@ export function Header() {
 
   return (
     <header
-      className={`sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 transition-all duration-300 ${
+      className={`sticky top-0 z-[60] w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 transition-all duration-300 ${
         isHeaderCollapsed ? 'h-0 overflow-hidden' : 'h-14'
       }`}
     >

--- a/components/HomePageClient.tsx
+++ b/components/HomePageClient.tsx
@@ -13,6 +13,7 @@ import {
   NumberFormsDialogTab,
 } from '@/lib/constants'
 import { useHeaderContext } from '@/lib/useHeaderContext'
+import { useOverflowControl } from '@/lib/useOverflowControl'
 import { NumberFormsDialog } from '@/components/NumberFormsDialog'
 import { NumberFormsSection } from '@/components/NumberFormsSection'
 // import { BuyMeACoffeeWidget } from '@/components/BuyMeACoffeeWidget'
@@ -45,6 +46,9 @@ export function HomePageClient() {
     const saved = localStorage.getItem(LOCAL_STORAGE_KEYS.HAS_SEEN_FIRST_TIME_TOAST)
     return saved !== null ? JSON.parse(saved) : false
   })
+
+  // Control HTML overflow based on whether scrollable content is present
+  useOverflowControl(showNumberFormsSection)
 
   const cards = useMemo(() => {
     if (!inputNumber) return []

--- a/components/HomePageClient.tsx
+++ b/components/HomePageClient.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/lib/constants'
 import { useHeaderContext } from '@/lib/useHeaderContext'
 import { NumberFormsDialog } from '@/components/NumberFormsDialog'
+import { NumberFormsSection } from '@/components/NumberFormsSection'
 // import { BuyMeACoffeeWidget } from '@/components/BuyMeACoffeeWidget'
 import { toast } from 'sonner'
 import { FirstTimeToast } from '@/components/FirstTimeToast'
@@ -30,6 +31,8 @@ export function HomePageClient() {
     showZeroCards,
     showNumberFormsDialog,
     setShowNumberFormsDialog,
+    showNumberFormsSection,
+    setShowNumberFormsSection,
     isHeaderCollapsed,
     setCardsMoved,
     numberInputRef,
@@ -64,8 +67,9 @@ export function HomePageClient() {
       setResetTrigger(0)
       setRandomizeTrigger(0)
       setCardsMoved(false)
+      setShowNumberFormsSection(false)
     }
-  }, [inputNumber, setResetTrigger, setRandomizeTrigger, setCardsMoved])
+  }, [inputNumber, setResetTrigger, setRandomizeTrigger, setCardsMoved, setShowNumberFormsSection])
 
   useEffect(() => {
     window.scrollTo(0, 0)
@@ -132,6 +136,16 @@ export function HomePageClient() {
           )}
         </main>
       </section>
+
+      {/* Number Forms Section - Inline display below cards */}
+      <div id="number-forms-section" className="w-full container mx-auto">
+        <NumberFormsSection
+          number={inputNumber}
+          selectedTab={selectedTab}
+          setSelectedTab={setSelectedTab}
+          isVisible={showNumberFormsSection}
+        />
+      </div>
     </>
   )
 }

--- a/components/NumberFormsSection.tsx
+++ b/components/NumberFormsSection.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { Layers } from 'lucide-react'
+import { Tabs, TabsTrigger, TabsList, TabsContent } from '@/components/ui/tabs'
+import { ExpandedForm } from './number-representations/ExpandedForm'
+import { StandardForm } from './number-representations/StandardForm'
+import { WordForm } from './number-representations/WordForm'
+import { UnitForm } from './number-representations/UnitForm'
+import { NumberFormsDialogTab } from '@/lib/constants'
+import { Separator } from '@/components/ui/separator'
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+
+interface NumberFormsSectionProps {
+  number: number | null
+  selectedTab: NumberFormsDialogTab
+  setSelectedTab: (tab: NumberFormsDialogTab) => void
+  isVisible: boolean
+}
+
+export function NumberFormsSection({ number, selectedTab, setSelectedTab, isVisible }: NumberFormsSectionProps) {
+  if (!number || !isVisible) return null
+
+  return (
+    <section className="w-full animate-in slide-in-from-bottom-4 duration-300 py-8 px-4">
+      <Card className="w-full max-w-4xl mx-auto shadow-lg">
+        <CardHeader className="text-center">
+          <CardTitle className="flex items-center justify-center gap-2 text-2xl">
+            <Layers className="h-6 w-6" />
+            Number Forms & Representations
+          </CardTitle>
+          <Separator className="my-2" />
+          <CardDescription className="text-lg">
+            Explore different ways to write and understand the number <strong>{number.toLocaleString()}</strong>!
+          </CardDescription>
+        </CardHeader>
+
+        <CardContent>
+          <Tabs value={selectedTab} onValueChange={(value) => setSelectedTab(value as NumberFormsDialogTab)}>
+            <div className="flex flex-col gap-6 items-center">
+              <TabsList className="grid w-full max-w-2xl grid-cols-2 md:grid-cols-4">
+                <TabsTrigger value={NumberFormsDialogTab.STANDARD} className="text-xs md:text-sm">Standard Form</TabsTrigger>
+                <TabsTrigger value={NumberFormsDialogTab.WORD} className="text-xs md:text-sm">Word Form</TabsTrigger>
+                <TabsTrigger value={NumberFormsDialogTab.UNIT} className="text-xs md:text-sm">Unit Form</TabsTrigger>
+                <TabsTrigger value={NumberFormsDialogTab.EXPANDED} className="text-xs md:text-sm">Expanded Form</TabsTrigger>
+              </TabsList>
+              
+              <div className="w-full max-w-md relative">
+                <TabsContent value={NumberFormsDialogTab.EXPANDED} className="mt-0">
+                  <ExpandedForm number={number} />
+                </TabsContent>
+                <TabsContent value={NumberFormsDialogTab.STANDARD} className="mt-0">
+                  <StandardForm number={number} />
+                </TabsContent>
+                <TabsContent value={NumberFormsDialogTab.WORD} className="mt-0">
+                  <WordForm number={number} />
+                </TabsContent>
+                <TabsContent value={NumberFormsDialogTab.UNIT} className="mt-0">
+                  <UnitForm number={number} />
+                </TabsContent>
+              </div>
+            </div>
+          </Tabs>
+        </CardContent>
+      </Card>
+    </section>
+  )
+}

--- a/components/Toolbar.tsx
+++ b/components/Toolbar.tsx
@@ -19,6 +19,8 @@ export function Toolbar() {
     showZeroCards,
     toggleZeroCards,
     setShowNumberFormsDialog,
+    showNumberFormsSection,
+    setShowNumberFormsSection,
     cardsMoved,
     focusNumberInput,
   } = useHeaderContext()
@@ -113,10 +115,21 @@ export function Toolbar() {
               variant="outline"
               disabled={!inputNumber}
               size="sm"
-              onClick={() => setShowNumberFormsDialog(true)}
+              onClick={() => {
+                setShowNumberFormsSection(!showNumberFormsSection)
+                // Scroll to the section after a brief delay to allow for render
+                if (!showNumberFormsSection) {
+                  setTimeout(() => {
+                    const section = document.getElementById('number-forms-section')
+                    if (section) {
+                      section.scrollIntoView({ behavior: 'smooth', block: 'start' })
+                    }
+                  }, 100)
+                }
+              }}
               title={
                 inputNumber
-                  ? `Number Forms & Representations for ${inputNumber?.toLocaleString()}`
+                  ? `${showNumberFormsSection ? 'Hide' : 'Show'} Number Forms & Representations for ${inputNumber?.toLocaleString()}`
                   : 'Number Forms & Representations'
               }
             >

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -29,7 +29,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-[70] max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
           className
         )}
         {...props}

--- a/lib/useHeaderContext.tsx
+++ b/lib/useHeaderContext.tsx
@@ -26,6 +26,8 @@ interface HeaderContextType {
   toggleZeroCards: () => void
   showNumberFormsDialog: boolean
   setShowNumberFormsDialog: (value: boolean) => void
+  showNumberFormsSection: boolean
+  setShowNumberFormsSection: (value: boolean) => void
   cardsMoved: boolean
   setCardsMoved: (value: boolean) => void
   numberInputRef: React.RefObject<NumberInputRef | null>
@@ -51,6 +53,7 @@ export function HeaderProvider({ children }: { children: ReactNode }) {
   const [isDiceRolling, setIsDiceRolling] = useState(false)
   const [showZeroCards, setShowZeroCards] = useState(true)
   const [showNumberFormsDialog, setShowNumberFormsDialog] = useState(false)
+  const [showNumberFormsSection, setShowNumberFormsSection] = useState(false)
   const [cardsMoved, setCardsMoved] = useState(false)
 
   const numberInputRef = useRef<NumberInputRef>(null)
@@ -140,6 +143,8 @@ export function HeaderProvider({ children }: { children: ReactNode }) {
         toggleZeroCards,
         showNumberFormsDialog,
         setShowNumberFormsDialog,
+        showNumberFormsSection,
+        setShowNumberFormsSection,
         cardsMoved,
         setCardsMoved,
         numberInputRef,

--- a/lib/useOverflowControl.tsx
+++ b/lib/useOverflowControl.tsx
@@ -15,9 +15,20 @@ export function useOverflowControl(hasScrollableContent: boolean) {
       htmlElement.classList.remove('overflow-hidden')
       htmlElement.classList.add('overflow-auto')
     } else {
-      // Add overflow-hidden to prevent scrolling when no scrollable content
-      htmlElement.classList.remove('overflow-auto')
-      htmlElement.classList.add('overflow-hidden')
+      // When closing scrollable content, scroll to top first, then lock
+      if (window.scrollY > 0) {
+        window.scrollTo({ top: 0, behavior: 'smooth' })
+        
+        // Wait for scroll animation to complete before locking
+        setTimeout(() => {
+          htmlElement.classList.remove('overflow-auto')
+          htmlElement.classList.add('overflow-hidden')
+        }, 500) // 500ms to allow smooth scroll to complete
+      } else {
+        // If already at top, immediately lock
+        htmlElement.classList.remove('overflow-auto')
+        htmlElement.classList.add('overflow-hidden')
+      }
     }
 
     // Cleanup function to ensure we don't leave the page in a bad state

--- a/lib/useOverflowControl.tsx
+++ b/lib/useOverflowControl.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { useEffect } from 'react'
+
+/**
+ * Hook to control HTML overflow based on content visibility
+ * @param hasScrollableContent - Whether there is content that needs scrolling
+ */
+export function useOverflowControl(hasScrollableContent: boolean) {
+  useEffect(() => {
+    const htmlElement = document.documentElement
+    
+    if (hasScrollableContent) {
+      // Remove overflow-hidden to allow scrolling
+      htmlElement.classList.remove('overflow-hidden')
+      htmlElement.classList.add('overflow-auto')
+    } else {
+      // Add overflow-hidden to prevent scrolling when no scrollable content
+      htmlElement.classList.remove('overflow-auto')
+      htmlElement.classList.add('overflow-hidden')
+    }
+
+    // Cleanup function to ensure we don't leave the page in a bad state
+    return () => {
+      htmlElement.classList.remove('overflow-hidden', 'overflow-auto')
+      htmlElement.classList.add('overflow-auto') // Default to scrollable
+    }
+  }, [hasScrollableContent])
+}


### PR DESCRIPTION
Replace the Number Forms dialog with an inline section to allow side-by-side comparison with number cards, improving user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-d7f626b9-c4eb-401b-945b-741197a3943b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d7f626b9-c4eb-401b-945b-741197a3943b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

